### PR TITLE
Herlihy skiplist: reduce mem allocs/frees by using thread-specific data

### DIFF
--- a/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
+++ b/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
@@ -47,6 +47,8 @@
 #define XSTR(s)                         STR(s)
 #define STR(s)                          #s
 
+extern pthread_key_t preds_key;
+extern pthread_key_t succs_key;
 extern volatile AO_t stop;
 extern unsigned int global_seed;
 /* Skip list level */


### PR DESCRIPTION
Utilize thread local storage to significantly reduce memory allocations and memory frees.

Improves read only throughput by at least double, non significant impact on update workloads.

[Benchmarks](http://i.imgur.com/ahqvkZs.png) on 4x AMD Opteron 6378

(Using the stack similarly improves performance, let me know if you prefer a pull request for that solution.)