### PR TITLE
Test.java: increase total counters to long from int

### DIFF
--- a/java/src/contention/benchmark/Test.java
+++ b/java/src/contention/benchmark/Test.java
@@ -39,18 +39,18 @@ public class Test {
 	private double throughput = 0;
 
 	/** The total number of operations for all threads */
-	private int total = 0;
+	private long total = 0;
 	/** The total number of successful operations for all threads */
-	private int numAdd = 0;
-	private int numRemove = 0;
-	private int numAddAll = 0;
-	private int numRemoveAll = 0;
-	private int numSize = 0;
-	private int numContains = 0;
+	private long numAdd = 0;
+	private long numRemove = 0;
+	private long numAddAll = 0;
+	private long numRemoveAll = 0;
+	private long numSize = 0;
+	private long numContains = 0;
 	/** The total number of failed operations for all threads */
-	private int failures = 0;
+	private long failures = 0;
 	/** The total number of aborts */
-	private int aborts = 0;
+	private long aborts = 0;
 	/** The instance of the benchmark */
 	private Type benchType = null;
 	private CompositionalIntSet setBench = null;


### PR DESCRIPTION
**Overview:**
Counters of the thread operations are `long`. Total counters of the operations are `int`. The total counter ints can easily overflow when summing the thread counter longs. A reasonable improvement is to at least use longs for the total counters.

**Example of issue:**
```
-------------------------------------------------------------------------------
Benchmark statistics
-------------------------------------------------------------------------------
  Average traversal length: 	NaN
  Struct Modifications:     	0
  Throughput (ops/s):       	-2.676355275832961E7
  Elapsed time (s):         	20.139
  Operations:               	-538991189	( 100 %)
    effective updates:     	    0	( -0.00 %)
    |--add successful:     	    0	( -0.00 %)
    |--remove succ.:       	    0	( -0.00 %)
    |--addAll succ.:       	    0	( -0.00 %)
    |--removeAll succ.:    	    0	( -0.00 %)
    size successful:       	    0	( -0.00 %)
    contains succ.:        	    1877979207	( -348.42 %)
    unsuccessful ops:      	    1877996900	( -348.43 %)
  Final size:              	    128
  Expected size:           	    128
```

**Example after commit:**
```
-------------------------------------------------------------------------------
Benchmark statistics
-------------------------------------------------------------------------------
  Average traversal length: 	NaN
  Struct Modifications:     	0
  Throughput (ops/s):       	2.0803328965037054E8
  Elapsed time (s):         	20.107
  Operations:               	4182925355	( 100 %)
    effective updates:     	    0	( 0.00 %)
    |--add successful:     	    0	( 0.00 %)
    |--remove succ.:       	    0	( 0.00 %)
    |--addAll succ.:       	    0	( 0.00 %)
    |--removeAll succ.:    	    0	( 0.00 %)
    size successful:       	    0	( 0.00 %)
    contains succ.:        	    2091453044	( 50.00 %)
    unsuccessful ops:      	    2091472311	( 50.00 %)
  Final size:                  	128
  Expected size:               	128
-------------------------------------------------------------------------------
```