### PR TITLE
Thread-safety of random number generators.

### DIFF
--- a/c-cpp/src/hashtables/lockbased-ht/test.c
+++ b/c-cpp/src/hashtables/lockbased-ht/test.c
@@ -62,6 +62,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -75,7 +77,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/hashtables/lockfree-ht/test.c
+++ b/c-cpp/src/hashtables/lockfree-ht/test.c
@@ -70,6 +70,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -83,7 +85,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/linkedlists/lazy-list/test.c
+++ b/c-cpp/src/linkedlists/lazy-list/test.c
@@ -59,6 +59,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given program options [r]ange and [i]nitial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
   int m = RAND_MAX;
@@ -72,7 +74,7 @@ inline long rand_range(long r) {
   return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
   int m = RAND_MAX;
   int d, v = 0;

--- a/c-cpp/src/linkedlists/lock-coupling-list/test.c
+++ b/c-cpp/src/linkedlists/lock-coupling-list/test.c
@@ -59,6 +59,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given program options [r]ange and [i]nitial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
   int m = RAND_MAX;
@@ -72,7 +74,7 @@ inline long rand_range(long r) {
   return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
   int m = RAND_MAX;
   int d, v = 0;

--- a/c-cpp/src/linkedlists/lockfree-list/test.c
+++ b/c-cpp/src/linkedlists/lockfree-list/test.c
@@ -61,6 +61,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given program options [r]ange and [i]nitial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
   //int m = RAND_MAX;
@@ -75,7 +77,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = 2147483647;
 	long d, v = 0;

--- a/c-cpp/src/linkedlists/selfish/test.c
+++ b/c-cpp/src/linkedlists/selfish/test.c
@@ -109,6 +109,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given program options [r]ange and [i]nitial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = 2147483647;
@@ -122,10 +124,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/*
- * Re-entrant version of rand_range(r) 
- * returns values in the range [1, r]
- */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = 2147483647;
 	long d, v = 0;

--- a/c-cpp/src/linkedlists/versioned/test.c
+++ b/c-cpp/src/linkedlists/versioned/test.c
@@ -92,6 +92,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might
  * be too high for given program options [r]ange and [i]nitial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
   //int m = RAND_MAX;
@@ -106,8 +108,7 @@ inline long rand_range(long r) {
     return v;
 }
 
-/* Re-entrant version of rand_range(r) */
-// Returns values in the range [1, r]
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
     int m = 2147483647;
     long d, v = 0;

--- a/c-cpp/src/skiplists/fraser/test.c
+++ b/c-cpp/src/skiplists/fraser/test.c
@@ -121,6 +121,8 @@ int floor_log_2(unsigned int n) {
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -134,7 +136,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/skiplists/nohotspot/test.c
+++ b/c-cpp/src/skiplists/nohotspot/test.c
@@ -126,6 +126,8 @@ int floor_log_2(unsigned int n) {
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -139,7 +141,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/skiplists/rotating/test.c
+++ b/c-cpp/src/skiplists/rotating/test.c
@@ -122,6 +122,8 @@ int floor_log_2(unsigned int n) {
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -135,7 +137,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/skiplists/sequential/skiplist.c
+++ b/c-cpp/src/skiplists/sequential/skiplist.c
@@ -25,16 +25,30 @@
 
 unsigned int levelmax;
 
+/*
+ * Returns a random level for inserting a new node, results are hardwired to p=0.5, min=1, max=32.
+ *
+ * "Xorshift generators are extremely fast non-cryptographically-secure random number generators on
+ * modern architectures."
+ *
+ * Marsaglia, George, (July 2003), "Xorshift RNGs", Journal of Statistical Software 8 (14)
+ */
 int get_rand_level() {
-	int i, level = 1;
-	for (i = 0; i < levelmax - 1; i++) {
-		if ((rand_range(100)-1) < 50)
-			level++;
-		else
-			break;
+	static uint32_t y = 2463534242UL;
+	y^=(y<<13);
+	y^=(y>>17);
+	y^=(y<<5);
+	uint32_t temp = y;
+	uint32_t level = 1;
+	while (((temp >>= 1) & 1) != 0) {
+		++level;
 	}
 	/* 1 <= level <= levelmax */
-	return level;
+	if (level > levelmax) {
+		return (int)levelmax;
+	} else {
+		return (int)level;
+	}
 }
 
 int floor_log_2(unsigned int n) {

--- a/c-cpp/src/skiplists/sequential/skiplist.h
+++ b/c-cpp/src/skiplists/sequential/skiplist.h
@@ -89,5 +89,3 @@ void sl_delete_node(sl_node_t *n);
 sl_intset_t *sl_set_new();
 void sl_set_delete(sl_intset_t *set);
 unsigned long sl_set_size(sl_intset_t *set);
-
-inline long rand_range(long r); /* declared in test.c */

--- a/c-cpp/src/skiplists/sequential/test.c
+++ b/c-cpp/src/skiplists/sequential/test.c
@@ -68,6 +68,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -81,7 +83,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.c
+++ b/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.c
@@ -35,36 +35,30 @@ inline void *xmalloc(size_t size)
 	return p;
 }
 
-
-/* 
- * Returns a pseudo-random value in [1;range).
- * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
- * the granularity of rand() could be lower-bounded by the 32767^th which might 
- * be too high for given values of range and initial.
+/*
+ * Returns a random level for inserting a new node, results are hardwired to p=0.5, min=1, max=32.
+ *
+ * "Xorshift generators are extremely fast non-cryptographically-secure random number generators on
+ * modern architectures."
+ *
+ * Marsaglia, George, (July 2003), "Xorshift RNGs", Journal of Statistical Software 8 (14)
  */
-inline long rand_range(long r) {
-	int m = RAND_MAX;
-	long d, v = 0;
-	
-	do {
-		d = (m > r ? r : m);		
-		v += 1 + (long)(d * ((double)rand()/((double)(m)+1.0)));
-		r -= m;
-	} while (r > 0);
-	return v;
-}
-
-
 int get_rand_level() {
-	int i, level = 1;
-	for (i = 0; i < levelmax - 1; i++) {
-		if ((rand_range(100)-1) < 50)
-			level++;
-		else
-			break;
+	static uint32_t y = 2463534242UL;
+	y^=(y<<13);
+	y^=(y>>17);
+	y^=(y<<5);
+	uint32_t temp = y;
+	uint32_t level = 1;
+	while (((temp >>= 1) & 1) != 0) {
+		++level;
 	}
 	/* 1 <= level <= levelmax */
-	return level;
+	if (level > levelmax) {
+		return (int)levelmax;
+	} else {
+		return (int)level;
+	}
 }
 
 int floor_log_2(unsigned int n) {

--- a/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
+++ b/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
@@ -112,11 +112,3 @@ void sl_delete_node(sl_node_t *n);
 sl_intset_t *sl_set_new();
 void sl_set_delete(sl_intset_t *set);
 int sl_set_size(sl_intset_t *set);
-
-/* 
- * Returns a pseudo-random value in [1;range).
- * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
- * the granularity of rand() could be lower-bounded by the 32767^th which might 
- * be too high for given values of range and initial.
- */
-inline long rand_range(long r);

--- a/c-cpp/src/skiplists/skiplist-lock/test.c
+++ b/c-cpp/src/skiplists/skiplist-lock/test.c
@@ -65,7 +65,27 @@ void barrier_cross(barrier_t *b)
   pthread_mutex_unlock(&b->mutex);
 }
 
-/* Re-entrant version of rand_range(r) */
+/* 
+ * Returns a pseudo-random value in [1;range).
+ * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
+ * the granularity of rand() could be lower-bounded by the 32767^th which might 
+ * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
+ */
+inline long rand_range(long r) {
+	int m = RAND_MAX;
+	int d, v = 0;
+	
+	do {
+		d = (m > r ? r : m);		
+		v += 1 + (int)(d * ((double)rand()/((double)(m)+1.0)));
+		r -= m;
+	} while (r > 0);
+	return v;
+}
+
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
   int m = RAND_MAX;
   long d, v = 0;

--- a/c-cpp/src/trees/avl/move_test.c
+++ b/c-cpp/src/trees/avl/move_test.c
@@ -71,6 +71,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -84,7 +86,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/trees/avl/test.c
+++ b/c-cpp/src/trees/avl/test.c
@@ -73,6 +73,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -96,7 +98,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/avl/test_nested.c
+++ b/c-cpp/src/trees/avl/test_nested.c
@@ -73,6 +73,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -96,7 +98,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/lfbstree/test.c
+++ b/c-cpp/src/trees/lfbstree/test.c
@@ -87,6 +87,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -110,7 +112,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/newavltree/move_test.c
+++ b/c-cpp/src/trees/newavltree/move_test.c
@@ -71,6 +71,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -84,7 +86,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/trees/newavltree/test.c
+++ b/c-cpp/src/trees/newavltree/test.c
@@ -69,6 +69,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -83,7 +85,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/newavltree/test_nested.c
+++ b/c-cpp/src/trees/newavltree/test_nested.c
@@ -73,6 +73,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -96,7 +98,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/rbtree/test.c
+++ b/c-cpp/src/trees/rbtree/test.c
@@ -68,6 +68,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -81,7 +83,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/trees/sftree/test.c
+++ b/c-cpp/src/trees/sftree/test.c
@@ -74,6 +74,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -97,7 +99,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/sftree/test_move.c
+++ b/c-cpp/src/trees/sftree/test_move.c
@@ -73,6 +73,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 inline long rand_range(long r) {
 	int m = RAND_MAX;
@@ -86,7 +88,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	long d, v = 0;

--- a/c-cpp/src/trees/sftree/test_nested.c
+++ b/c-cpp/src/trees/sftree/test_nested.c
@@ -75,6 +75,8 @@ void barrier_cross(barrier_t *b)
  * Depending on the symbolic constant RAND_MAX>=32767 defined in stdlib.h,
  * the granularity of rand() could be lower-bounded by the 32767^th which might 
  * be too high for given values of range and initial.
+ *
+ * Note: this is not thread-safe and will introduce futex locks
  */
 
 inline long rand_range(long r) {
@@ -98,7 +100,7 @@ inline long rand_range(long r) {
 	return v;
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
 	int m = RAND_MAX;
 	int d, v = 0;

--- a/c-cpp/src/trees/tree-lock/test.c
+++ b/c-cpp/src/trees/tree-lock/test.c
@@ -144,7 +144,7 @@ void barrier_cross(barrier_t *b)
   pthread_mutex_unlock(&b->mutex);
 }
 
-/* Re-entrant version of rand_range(r) */
+/* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
   int m = RAND_MAX;
   long d, v = 0;


### PR DESCRIPTION
**Issue:**
A non-thread-safe and non-reentrant random number generator was being utilized by some skip lists to select the height of new nodes being inserted.

When concurrent threads are using rand() [futex](https://en.wikipedia.org/wiki/Futex) locks are introduced which _significantly_ lowers performance.

**Excerpt from `man 3 rand`**

> The function rand() is not reentrant or thread-safe, since it uses hidden state that is modified on each call.  This might just be the  seed value  to  be  used by the next call, or it might be something more elaborate.  In order to get reproducible behavior in a threaded application, this state must be made explicit; this can be done using the reentrant function rand_r().

**Solution:**
Concurrent threads should use a thread-safe and reentrant random number generator.

This pull request implements xorshift32 random number generator in the sequential and skiplist-lock (Herlihy's optimistic) skip lists. Additionally adds thread-safety information in all the comments for rand_range() and rand_range_re().

Xorshift generators are extremely fast non-cryptographically-secure random number generators on modern architectures (except microprocessors).

**Performance Increase:**
Utilizing xorshift ([graphs](http://i.imgur.com/gMAU0F7.png) which include rand_r benchmarks) shows:

- AMD & Intel
  - Sequential skip list: 0% change in every workload
- AMD
  - Herlihy's skip list: 0% change under read-only workload
  - Herlihy's skip list: up to **166% throughput increase** under _10% update_ workload
  - Herlihy's skip list: up to **458% throughput increase** under _100% update_ workload
- Intel
  - Herlihy's skip list: 0% change under read-only workload
  - Herlihy's skip list: up to **43% throughput increase** under _10% update_ workload
  - Herlihy's skip list: up to **341% throughput increase** under _100% update_ workload

**Xorshift Paper:**
Marsaglia, George, (July 2003), "Xorshift RNGs", Journal of Statistical Software 8 (14)

**Raw RNG Performance on Intel:**
Time for _16_ threads to each produce 2^26 random numbers:

  - rand() = real	:12m33.438s user:10m22.336s _sys:184m43.816s_
  - rand_r() = real:2m12.845s user:33m39.724s sys:0m0.000s
  - xorshift32() = real:1m12.383s user:18m35.564s sys:0m0.004s

Time for a _single_ thread to produce 2^32 random numbers:

  - rand() = real:3m42.892s user:3m42.892s sys:0m0.000s
  - rand_r() = real:3m25.972s user:3m25.972s sys:0m0.000s
  - xorshift32() = real:1m40.228s user:1m40.228s sys:0m0.000s

**Systems:**
- 4x AMD Opteron(tm) Processor 6378 @ 2.40GHz with 256GB RAM gcc 5.3.0 
- 2x Intel(R) Xeon(R) CPU E5-2450 @ 2.10GHz with 128GB RAM gcc 4.8.1 

**Example `strace -f` output of concurrent threads using rand():**
```
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40569] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40570] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40569] <... futex resumed> )       = 0
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40568] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40570] <... futex resumed> )       = 0
[pid 40569] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40568] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40569] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40568] <... futex resumed> )       = 0
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40569] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40570] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40569] <... futex resumed> )       = 0
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40568] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40570] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40568] <... futex resumed> )       = 0
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40569] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40570] <... futex resumed> )       = 0
[pid 40569] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40570] futex(0x7fc4d88da750, FUTEX_WAIT_PRIVATE, 2, NULL <unfinished ...>
[pid 40569] futex(0x7fc4d88da750, FUTEX_WAKE_PRIVATE, 1 <unfinished ...>
[pid 40570] <... futex resumed> )       = -1 EAGAIN (Resource temporarily unavailable)
[pid 40569] <... futex resumed> )       = 0
```