### PR TITLE
Java lock-free skip lists: resolve bug limiting height to 15.

### DIFF
--- a/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
+++ b/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
@@ -1632,7 +1632,7 @@ public class NonBlockingFriendlySkipListMap<K, V> extends AbstractMap<K, V>
 		x ^= x << 13;
 		x ^= x >>> 17;
 		randomSeed = x ^= x << 5;
-		if ((x & 0x8001) != 0) // test highest and lowest bits
+		if ((x & 0x80000001) != 0) // test highest and lowest bits
 			return 0;
 		int level = 1;
 		while (((x >>>= 1) & 1) != 0)

--- a/java/src/skiplists/lockfree/NonBlockingJavaSkipListMap.java
+++ b/java/src/skiplists/lockfree/NonBlockingJavaSkipListMap.java
@@ -1029,7 +1029,7 @@ public class NonBlockingJavaSkipListMap<K, V> extends AbstractMap<K, V>
 		x ^= x << 13;
 		x ^= x >>> 17;
 		randomSeed = x ^= x << 5;
-		if ((x & 0x8001) != 0) // test highest and lowest bits
+		if ((x & 0x80000001) != 0) // test highest and lowest bits
 			return 0;
 		int level = 1;
 		while (((x >>>= 1) & 1) != 0)


### PR DESCRIPTION
**Issue:**
The shortcut to testing the bits utilizes a short, 0x8001,  instead of an integer for the bitwise and. This results in the maximum return value being 15 instead of the expected and documented value of 31.

This will therefore increase the traversal time for skip lists larger than 2^16. This affects the DougLea skip list and the NoHotSpot skip list which reused the random number generator.

**Solution:**
Use an integer, 0x80000001, for the bitwise and.

**Benchmarks**
This provides an approximate 6% throughput increase on a skip list of size 2^22 to 2^23, under read-only workloads. ([graphs](http://i.imgur.com/cEEx9j7.png))

Larger skip lists should display increasing benefits, as previously the traversal would start to become linear.

**Systems:**
- 4x AMD Opteron(tm) Processor 6378 @ 2.40GHz with 256GB RAM gcc 5.3.0 
- 2x Intel(R) Xeon(R) CPU E5-2450 @ 2.10GHz with 128GB RAM gcc 4.8.1 

**Reference:**
First reported in [JDK-6973189](https://bugs.openjdk.java.net/browse/JDK-6973189), however left unfixed in jdk6 and only fixed in jdk7 with [JDK-7005424](https://bugs.openjdk.java.net/browse/JDK-7005424).