### PR TITLE
Herlihy skiplist: add garbage collector, resolve scaling under contention

### DIFF
--- a/c-cpp/src/skiplists/skiplist-lock/Makefile
+++ b/c-cpp/src/skiplists/skiplist-lock/Makefile
@@ -9,6 +9,12 @@ CFLAGS += -std=gnu89
 
 all:	main
 
+ptst.o: ptst.h
+	$(CC) $(CFLAGS) -c -o $(BUILDIR)/ptst.o ptst.c -I.
+
+garbagecoll.o: garbagecoll.h ptst.h
+	$(CC) $(CFLAGS) -c -o $(BUILDIR)/garbagecoll.o garbagecoll.c -I.
+
 skiplist-lock.o:
 	$(CC) $(CFLAGS) -c -o $(BUILDIR)/skiplist-lock.o skiplist-lock.c
 
@@ -21,8 +27,8 @@ intset.o: skiplist-lock.h optimistic.h
 test.o: skiplist-lock.h optimistic.h intset.h
 	$(CC) $(CFLAGS) -c -o $(BUILDIR)/test.o test.c
 
-main: skiplist-lock.o optimistic.o intset.o test.o 
-	$(CC) $(CFLAGS) $(BUILDIR)/skiplist-lock.o $(BUILDIR)/optimistic.o $(BUILDIR)/intset.o $(BUILDIR)/test.o -o $(BINS) $(LDFLAGS)
+main: skiplist-lock.o optimistic.o intset.o test.o ptst.o garbagecoll.o
+	$(CC) $(CFLAGS) $(BUILDIR)/garbagecoll.o $(BUILDIR)/ptst.o $(BUILDIR)/skiplist-lock.o $(BUILDIR)/optimistic.o $(BUILDIR)/intset.o $(BUILDIR)/test.o -o $(BINS) $(LDFLAGS)
 
 clean:
 	-rm -f $(BINS) *.o

--- a/c-cpp/src/skiplists/skiplist-lock/common.h
+++ b/c-cpp/src/skiplists/skiplist-lock/common.h
@@ -1,0 +1,31 @@
+/*
+ * common definitions shared by all modules
+ */
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#include <atomic_ops.h>
+
+#define VOLATILE /* volatile */
+#define BARRIER() asm volatile("" ::: "memory");
+
+#define CAS(_m, _o, _n) \
+    AO_compare_and_swap_full(((volatile AO_t*) _m), ((AO_t) _o), ((AO_t) _n))
+
+#define FAI(a) AO_fetch_and_add_full((volatile AO_t*) (a), 1)
+#define FAD(a) AO_fetch_and_add_full((volatile AO_t*) (a), -1)
+
+/*
+ * Allow us to efficiently align and pad structures so that shared fields
+ * don't cause contention on thread-local or read-only fields.
+ */
+#define CACHE_PAD(_n) char __pad ## _n [CACHE_LINE_SIZE]
+#define ALIGNED_ALLOC(_s)                                       \
+    ((void *)(((unsigned long)malloc((_s)+CACHE_LINE_SIZE*2) +  \
+        CACHE_LINE_SIZE - 1) & ~(CACHE_LINE_SIZE-1)))
+
+#define CACHE_LINE_SIZE 64
+
+
+
+#endif /* COMMON_H_ */

--- a/c-cpp/src/skiplists/skiplist-lock/garbagecoll.c
+++ b/c-cpp/src/skiplists/skiplist-lock/garbagecoll.c
@@ -1,0 +1,663 @@
+/*
+ * garbagecoll.c: garbage collection for the skip list
+ *
+ * Author: Ian Dick, 2013.
+ */
+
+/*
+
+Module overview
+
+This module includes all the functions needed to perform
+garbage collection during concurrenct use of the skip list.
+The approach used here is based on the one used by Keir Fraser
+in his lock-free skip list implementation, available here:
+http://www.cl.cam.ac.uk/research/srg/netos/lock-free
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "ptst.h"
+#include "garbagecoll.h"
+#include "skiplist-lock.h"
+
+#define NUM_EPOCHS 3
+#define MAX_HOOKS 4
+
+#define CHUNKS_PER_ALLOC 1000
+#define BLKS_PER_CHUNK 100
+#define ALLOC_CHUNKS_PER_LIST 300
+
+#define ADD_TO(_v,_x)                                                   \
+do {                                                                    \
+    unsigned long __val = (_v);                                         \
+    while (!CAS(&(_v),__val,__val+(_x)))                                \
+        __val = (_v);                                                   \
+} while ( 0 )
+
+#define MINIMAL_GC
+//#define PROFILE_GC
+
+typedef struct gc_chunk gc_chunk;
+struct gc_chunk {
+        struct gc_chunk *next;       /* chunk chaining */
+        unsigned int i;              /* next entry in blk to use */
+        void *blk[BLKS_PER_CHUNK];
+};
+
+static struct gc_global {
+
+        CACHE_PAD(0);
+
+        VOLATILE int current;           /* the current epoch */
+
+        CACHE_PAD(1);
+
+        VOLATILE unsigned long inreclaim;/* excl access to gc_reclaim() */
+
+        CACHE_PAD(2);
+
+        int page_size;                  /* memory page size in bytes */
+        unsigned long node_sizes;
+        int blk_sizes[MAX_SIZES];
+        unsigned long hooks;
+        gc_hookfn hook_fns[MAX_HOOKS];
+        gc_chunk * VOLATILE free_chunks; /* free, empty chunks */
+        gc_chunk * VOLATILE alloc[MAX_SIZES];
+        VOLATILE unsigned long alloc_size[MAX_SIZES];
+
+#ifdef PROFILE_GC
+        VOLATILE unsigned long total_size;
+        VOLATILE unsigned long allocations;
+        VOLATILE unsigned long alloc_chunk_num;
+        VOLATILE unsigned long num_reclaims;
+        VOLATILE unsigned long num_frees;
+#endif
+} gc_global;
+
+/* Per-thread state */
+struct gc_st {
+        unsigned int epoch;     /* epoch seen by this thread */
+
+        /* number of calls to gc_entry since last gc_reclaim() attempt */
+        unsigned int entries_since_reclaim;
+
+        /* used with gc_async_barrier() */
+        void *async_page;
+        int async_page_state;
+
+        /* garbage lists */
+        gc_chunk *garbage[NUM_EPOCHS][MAX_SIZES];
+        gc_chunk *garbage_tail[NUM_EPOCHS][MAX_SIZES];
+        gc_chunk *chunk_cache;
+
+        /* local allocation lists */
+        gc_chunk *alloc[MAX_SIZES];
+        unsigned int alloc_chunks[MAX_SIZES];
+
+        /* hook pointer lists */
+        gc_chunk *hook[NUM_EPOCHS][MAX_HOOKS];
+};
+
+/* - Private function forward declarations - */
+
+static gc_chunk* gc_alloc_more_chunks(void);
+static void gc_add_chunks_to_list(gc_chunk *ch, gc_chunk *head);
+static gc_chunk* gc_get_empty_chunks(int n);
+static struct gc_chunk* gc_get_filled_chunks(int n, int sz);
+static struct gc_chunk* gc_get_alloc_chunk(gc_st *gc, int i);
+#ifndef MINIMAL_GC
+static void gc_reclaim(void);
+#endif
+static struct gc_chunk* gc_chunk_from_cache(gc_st *gc);
+
+/* - Private function defintions - */
+
+/**
+ * alloc_more_chunks - alloc more empty chunks from the heap
+ *
+ * Returns a chain of chunks.
+ */
+static struct gc_chunk* gc_alloc_more_chunks(void)
+{
+        int i;
+        gc_chunk *h, *p;
+
+        h = ALIGNED_ALLOC(CHUNKS_PER_ALLOC * sizeof(gc_chunk));
+        if (!h) {
+                perror("Couldn't malloc chunks\n");
+                exit(1);
+        }
+        p = h;
+
+        for (i = 1; i < CHUNKS_PER_ALLOC; i++) {
+                p->next = p + 1;
+                ++p;
+        }
+        p->next = h;    /* close the loop */
+
+        return (h);
+}
+
+/**
+ * gc_add_chunks_to_list - put a chain of chunks onto a list
+ * @ch: the chain of chunks to add
+ * @head: the head of the list to add to
+ */
+static void gc_add_chunks_to_list(gc_chunk *ch, gc_chunk *head)
+{
+        gc_chunk *h_next, *ch_next;
+
+        ch_next = ch->next;
+        do {
+                ch->next = h_next = head->next;
+        } while (!CAS(&head->next, h_next, ch_next));
+}
+
+/**
+ * gc_get_empty_chunks - allocate a chain of @n empty chunks
+ * @n: the number of empty chunks to allocate
+ *
+ * Returns a pointer to the head of the chain.
+ * Note: Pointers may be garbage.
+ */
+static gc_chunk* gc_get_empty_chunks(int n)
+{
+        int i;
+        gc_chunk *new_rh, *rh, *rt, *head;
+
+retry:
+
+        head = gc_global.free_chunks;
+        do {
+                new_rh = head->next;
+                rh = new_rh;
+                rt = head;
+                for (i = 0; i < n; i++) {
+                        if ((rt = rt->next) == head) {
+                                gc_add_chunks_to_list(
+                                        gc_alloc_more_chunks(),head);
+                                goto retry;
+                        }
+                }
+        } while (!CAS(&head->next, rh, rt->next));
+
+        rt->next = rh; /* close the loop */
+        return rh;
+}
+
+/**
+ * gc_get_filled_chunks - get @n chunks pointing at size @sz blks
+ * @n: the number of filled chunks to get
+ * @sz: the size of blocks pointed to by each chunk
+ *
+ * Returns a pointer to the head of the chunk chain.
+ */
+static gc_chunk* gc_get_filled_chunks(int n, int sz)
+{
+        gc_chunk *h, *p;
+        char *node;
+        int i;
+
+#ifdef PROFILE_GC
+        ADD_TO(gc_global.total_size, (unsigned long) (n * BLKS_PER_CHUNK * sz));
+        ADD_TO(gc_global.allocations, 1);
+#endif
+
+        node = ALIGNED_ALLOC(n * BLKS_PER_CHUNK * sz);
+        if (!node) {
+                perror("malloc failed: gc_get_filled_chunks\n");
+                exit(1);
+        }
+
+        h = gc_get_empty_chunks(n);
+        p = h;
+        do {
+                p->i = BLKS_PER_CHUNK;
+                for (i = 0; i < BLKS_PER_CHUNK; i++) {
+                        p->blk[i] = node;
+                        node += sz;
+                }
+        } while ((p = p->next) != h);
+
+        return h;
+}
+
+/**
+ * gc_get_alloc_chunk - grab a chunk from the main chain
+ * @gc: the per-thread state for use by the calling thread
+ * @i: the level of the chunk to grab
+ */
+static gc_chunk* gc_get_alloc_chunk(gc_st *gc, int i)
+{
+        gc_chunk *alloc, *p, *nh;
+        unsigned int sz;
+
+        alloc = gc_global.alloc[i];
+        do {
+                p = alloc->next;
+                while (p == alloc) {
+
+                        #ifdef PROFILE_GC
+                        ADD_TO(gc_global.alloc_chunk_num, 1);
+                        #endif
+
+                        sz = gc_global.alloc_size[i];
+                        nh = gc_get_filled_chunks(sz,
+                                        gc_global.blk_sizes[i]);
+                        ADD_TO(gc_global.alloc_size[i], sz >> 3);
+                        /* gc_async_barrier(gc); */
+                        gc_add_chunks_to_list(nh, alloc);
+                        p = alloc->next;
+                }
+        } while (!CAS(&alloc->next, p, p->next));
+
+        p->next = p;
+        assert(BLKS_PER_CHUNK == p->i);
+
+        return p;
+}
+
+#ifndef MINIMAL_GC
+/**
+ * gc_reclaim - attempt to reclaim memory chunks from previous epochs
+ *
+ * Notes: Scan the list of perthread structs looking for the lowest
+ * max epoch number seen. If the lowest is the current epoch, then
+ * the "nearly-free" lists from the previous epoch are reclaimed, and
+ * the epoch is incremented.
+ */
+static void gc_reclaim(void)
+{
+        ptst_t  *ptst, *first_ptst, *our_ptst = NULL;
+        gc_st   *gc = NULL;
+        int     two_ago, three_ago, i, j;
+        gc_chunk *ch, *t;
+        unsigned long   curr_epoch;
+
+        /* barrier to entering the reclaim critical section */
+        if (gc_global.inreclaim || !CAS(&gc_global.inreclaim, 0, 1))
+                return;
+
+        /*
+         * grab first ptst structure *before* barrier -- prevents
+         * bugs on weak-ordered archs
+         */
+        first_ptst = ptst_first();
+
+        BARRIER();
+
+        curr_epoch = gc_global.current;
+
+        /* Have all threads seen the current epoch in mutator code? */
+        for (ptst = first_ptst; NULL != ptst; ptst = ptst_next(ptst)) {
+                if ((ptst->count > 1) && (ptst->gc->epoch != curr_epoch))
+                        goto out;
+        }
+
+        /*
+         * Three-epoch-old garbage lists move to allocation lists.
+         * Two-epoch-old garbage lists are cleaned out.
+         * XXX
+         */
+        two_ago   = (curr_epoch + 2) % NUM_EPOCHS;
+        three_ago = (curr_epoch + 1) % NUM_EPOCHS;
+
+        if ( 0 != gc_global.hooks)
+                our_ptst = (ptst_t *) pthread_getspecific(ptst_key);
+
+        for (ptst = first_ptst; NULL != ptst; ptst = ptst_next(ptst)) {
+                gc = ptst->gc;
+                for (i = 0; i < gc_global.node_sizes; i++) {
+                        /*
+                         * leave one chunk behind as it probably
+                         * isn't full yet
+                         */
+                        t = gc->garbage[three_ago][i];
+                        if ((NULL == t) || ((ch = t->next) == t))
+                                continue;
+                        gc->garbage_tail[three_ago][i]->next = ch;
+                        gc->garbage_tail[three_ago][i] = t;
+                        t->next = t;
+                        gc_add_chunks_to_list(ch, gc_global.alloc[i]);
+                }
+
+                /* XXX do we need this ? */
+
+                for (i = 0; i < gc_global.hooks; i++) {
+                        gc_hookfn fn = gc_global.hook_fns[i];
+                        ch = gc->hook[three_ago][i];
+                        if (NULL == ch)
+                                continue;
+                        gc->hook[three_ago][i] = NULL;
+
+                        t = ch;
+                        do {
+                                for (j = 0; j < t->i; j++)
+                                        fn(our_ptst, t->blk[j]);
+                        } while ((t = t->next) != ch);
+
+                        gc_add_chunks_to_list(ch, gc_global.free_chunks);
+                }
+        }
+
+        #ifdef PROFILE_GC
+        ADD_TO(gc_global.num_reclaims, 1);
+        #endif
+
+        /* update the current epoch */
+        BARRIER();
+        gc_global.current = (curr_epoch + 1) % NUM_EPOCHS;
+
+out:
+        gc_global.inreclaim = 0;
+}
+#endif
+
+/**
+ * gc_chunk_from_cache - ...
+ * @gc: ....
+ *
+ * Returns a reference to the chunk retrieved from the cache.
+ */
+static gc_chunk* gc_chunk_from_cache(gc_st *gc)
+{
+        gc_chunk *ch = gc->chunk_cache;
+        gc_chunk *p  = ch->next;
+
+        if (ch == p) {
+                gc->chunk_cache = gc_get_empty_chunks(100);
+        } else {
+                ch->next = p->next;
+                p->next = p;
+        }
+        p->i = 0;
+
+        return p;
+}
+
+/* - Public garbage collection routines - */
+
+/**
+ * gc_alloc - ...
+ * @ptst: the thread-local structure
+ * @alloc_id: ....
+ *
+ * Returns a reference to the alloc'd chunk.
+ */
+void* gc_alloc(ptst_t *ptst, int alloc_id)
+{
+        gc_st *gc = ptst->gc;
+        gc_chunk *ch;
+
+        ch = gc->alloc[alloc_id];
+        if (0 == ch->i) {
+                if (100 == gc->alloc_chunks[alloc_id]++) {
+                        gc->alloc_chunks[alloc_id] = 0;
+                        gc_add_chunks_to_list(ch, gc_global.free_chunks);
+                        ch = gc_get_alloc_chunk(gc, alloc_id);
+                        gc->alloc[alloc_id] = ch;
+                } else {
+                        gc_chunk *och = ch;
+                        ch = gc_get_alloc_chunk(gc, alloc_id);
+                        ch->next = och->next;
+                        och->next = ch;
+                        gc->alloc[alloc_id] = ch;
+                }
+        }
+
+        return ch->blk[--ch->i];
+}
+
+/**
+ * gc_free - free some memory
+ * @ptst: the per-thread state
+ * @p: pointer to the memory to free
+ * @alloc_id: the level of the memory being free'd
+ */
+void gc_free(ptst_t *ptst, void *p, int alloc_id)
+{
+#ifndef MINIMAL_GC
+
+        gc_st *gc = ptst->gc;
+        gc_chunk *prev, *new;
+        gc_chunk *ch = gc->garbage[gc->epoch][alloc_id];
+
+        if (NULL == ch) {
+                ch = gc_chunk_from_cache(gc);
+                gc->garbage[gc->epoch][alloc_id] = ch;
+                gc->garbage_tail[gc->epoch][alloc_id] = ch;
+        } else if (BLKS_PER_CHUNK == ch->i) {
+                prev = gc->garbage_tail[gc->epoch][alloc_id];
+                new = gc_chunk_from_cache(gc);
+                gc->garbage[gc->epoch][alloc_id] = new;
+                new->next = ch;
+                prev->next = new;
+                ch = new;
+        }
+
+        ch->blk[ch->i++] = p;
+
+        #ifdef PROFILE_GC
+        ADD_TO(gc_global.num_frees, 1);
+        #endif
+#endif
+}
+
+/**
+ * gc_add_ptr_to_hook_list - ...
+ * @ptst: per-thread state
+ * @p: the ptr to add to the hook list
+ * @hook_id: the hook id we are using
+ */
+void gc_add_ptr_to_hook_list(ptst_t *ptst, void *p, int hook_id)
+{
+        gc_st *gc = ptst->gc;
+        gc_chunk *och;
+        gc_chunk *ch = gc->hook[gc->epoch][hook_id];
+
+        if (NULL == ch) {
+                ch = gc_chunk_from_cache(gc);
+                gc->hook[gc->epoch][hook_id] = ch;
+        } else {
+                ch = ch->next;
+                if (BLKS_PER_CHUNK == ch->i) {
+                        och = gc->hook[gc->epoch][hook_id];
+                        ch = gc_chunk_from_cache(gc);
+                        ch->next = och->next;
+                        och->next = ch;
+                }
+        }
+
+        ch->blk[ch->i++] = p;
+}
+
+/**
+ * gc_unsafe_free - ...
+ * @ptst: per-thread state
+ * @p: pointer to the memory we are freeing
+ * @alloc_id: the level of memory we are freeing
+ */
+void gc_unsafe_free(ptst_t *ptst, void *p, int alloc_id)
+{
+        gc_st *gc = ptst->gc;
+        gc_chunk *ch;
+
+        ch = gc->alloc[alloc_id];
+        if (ch->i < BLKS_PER_CHUNK)
+                ch->blk[ch->i++] = p;
+        else
+                gc_free(ptst, p, alloc_id);
+}
+
+/**
+ * gc_enter - enter a critical setion
+ * @ptst: per-thread state
+ */
+void gc_enter(ptst_t *ptst)
+{
+#ifdef MINIMAL_GC
+        ptst->count++;
+        BARRIER();
+#else
+        gc_st *gc = ptst->gc;
+        int new_epoch, cnt;
+
+retry:
+
+        cnt = ptst->count++;
+        BARRIER();
+        if (1 == cnt) {
+                new_epoch = gc_global.current;
+                if (gc->epoch != new_epoch) {
+                        gc->epoch = new_epoch;
+                        gc->entries_since_reclaim = 0;
+                } else if (gc->entries_since_reclaim++ == 100) {
+                        --ptst->count;
+                        gc->entries_since_reclaim = 0;
+                        gc_reclaim();
+                        goto retry;
+                }
+        }
+#endif
+}
+
+/**
+ * gc_exit - exit a critical section
+ * @ptst: per-thread state
+ */
+void gc_exit(ptst_t *ptst)
+{
+        BARRIER();
+        ptst->count--;
+}
+
+/**
+ * gc_init - initialise a garbage collection structure and return it
+ *
+ * Returns the initialised garbage collection structure.
+ */
+gc_st* gc_init(void)
+{
+        gc_st *gc;
+        int i;
+
+        gc = ALIGNED_ALLOC(sizeof(gc_st));
+        if (NULL == gc) {
+                perror("malloc failed: gc_init\n");
+                exit(1);
+        }
+        memset(gc, 0, sizeof(*gc));
+
+        gc->chunk_cache = gc_get_empty_chunks(100);
+
+        /* get ourselves a set of allocation chunks */
+        for (i = 0; i < gc_global.node_sizes; i++)
+                gc->alloc[i] = gc_get_alloc_chunk(gc, i);
+        for ( ; i < MAX_SIZES; i++)
+                gc->alloc[i] = gc_chunk_from_cache(gc);
+
+        return gc;
+}
+
+/**
+ * gc_add_allocator - add a new gc allocator
+ * @alloc_size: the size blocks to use for this allocator
+ *
+ * Returns the old number of node sizes.
+ */
+int gc_add_allocator(int alloc_size)
+{
+        int i = gc_global.node_sizes;
+
+        while (!CAS(&(gc_global.node_sizes), i, i+1))
+                i = gc_global.node_sizes;
+
+        gc_global.blk_sizes[i] = alloc_size;
+        gc_global.alloc_size[i] = ALLOC_CHUNKS_PER_LIST;
+        gc_global.alloc[i] = gc_get_filled_chunks(ALLOC_CHUNKS_PER_LIST,
+                                                  alloc_size);
+
+        #ifdef PROFILE_GC
+        printf("Added a new allocator of size %d bytes ", alloc_size);
+        printf("with alloc size %lu bytes\n", gc_global.alloc_size[i]);
+        #endif
+
+        return i;
+}
+
+/**
+ * gc_remove_allocator -
+ * @alloc_id: ...
+ */
+void gc_remove_allocator(int alloc_id)
+{
+        /* noop */
+}
+
+/**
+ * gc_add_hook - ...
+ * @fn: the function to add
+ *
+ * Returns ...
+ */
+int gc_add_hook(gc_hookfn fn)
+{
+        int i = gc_global.hooks;
+
+        while (!CAS(&gc_global.hooks, i, i+1))
+                i = gc_global.hooks;
+
+        gc_global.hook_fns[i] = fn;
+
+        return i;
+}
+
+/**
+ * gc_remove_hook - ...
+ * @hook_id: ...
+ */
+void gc_remove_hook(int hook_id)
+{
+        /* noop */
+}
+
+/**
+ * gc_subsystem_destroy - ...
+ */
+void gc_subsystem_destroy(void)
+{
+#ifdef PROFILE_GC
+        printf("Total heap: %lu bytes (%.2fMB) in %lu allocations\n",
+                gc_global.total_size,
+                (double) gc_global.total_size / 1000000,
+                gc_global.allocations);
+        printf("Node alloc size = %lu\n", gc_global.alloc_size[0]);
+        printf("Inode alloc size = %lu\n", gc_global.alloc_size[1]);
+        printf("alloc chunk num = %lu\n", gc_global.alloc_chunk_num);
+        printf("Num reclaims = %lu\n", gc_global.num_reclaims);
+        printf("Num frees = %lu\n", gc_global.num_frees);
+#endif
+}
+
+/**
+ * gc_subsystem_init - initialise the garbage collection subsystem
+ *
+ * Note: only happens once at the start of the program.
+ */
+void gc_subsystem_init(void)
+{
+        memset(&gc_global, 0, sizeof(gc_global));
+
+        gc_global.page_size = (unsigned int) sysconf(_SC_PAGESIZE);
+        gc_global.free_chunks = gc_alloc_more_chunks();
+
+        gc_global.hooks = 0;
+        gc_global.node_sizes = 0;
+}

--- a/c-cpp/src/skiplists/skiplist-lock/garbagecoll.h
+++ b/c-cpp/src/skiplists/skiplist-lock/garbagecoll.h
@@ -1,0 +1,39 @@
+/*
+ * interface for garbage collection
+ */
+
+#ifndef GARBAGECOLL_H_
+#define GARBAGECOLL_H_
+
+/* comment out to disable garbage collection */
+#define USE_GC
+
+#include "ptst.h"
+
+typedef struct gc_st gc_st;
+
+/* Initialise GC section of per-thread state */
+gc_st* gc_init(void);
+
+int gc_add_allocator(int alloc_size);
+void gc_remove_allocator(int alloc_id);
+
+void* gc_alloc(ptst_t *ptst, int alloc_id);
+void gc_free(ptst_t *ptst, void *p, int alloc_id);
+void gc_free_unsafe(ptst_t *ptst, void *p, int alloc_id);
+
+/* Hook registry - allows users to hook in their own epoch-delay lists */
+typedef void (*gc_hookfn)(ptst_t*, void*);
+int gc_add_hook(gc_hookfn hookfn);
+void gc_remove_hook(int hookid);
+void gc_hooklist_addptr(ptst_t *ptst, void *ptr, int hookid);
+
+/* Per-thread entry/exit from critical regions */
+void gc_enter(ptst_t* ptst);
+void gc_exit(ptst_t* ptst);
+
+/* Initialisation of GC */
+void gc_subsystem_init(void);
+void gc_subsystem_destroy(void);
+
+#endif /* GARBAGECOLL_H_ */

--- a/c-cpp/src/skiplists/skiplist-lock/optimistic.c
+++ b/c-cpp/src/skiplists/skiplist-lock/optimistic.c
@@ -150,7 +150,9 @@ int optimistic_insert(sl_intset_t *set, val_t val) {
       continue;
     }
 		
-    new_node = sl_new_simple_node(val, toplevel, 2);
+    ptst_t *ptst = ptst_critical_enter();
+    new_node = sl_new_simple_node(val, toplevel, 2, ptst);
+    ptst_critical_exit(ptst);
     for (i = 0; i < toplevel; i++) {
       new_node->next[i] = succs[i];
       preds[i]->next[i] = new_node;
@@ -233,6 +235,9 @@ int optimistic_delete(sl_intset_t *set, val_t val) {
 	preds[i]->next[i] = node_todel->next[i];
       UNLOCK(&node_todel->lock);	
       unlock_levels(preds, highest_locked, 22);
+      ptst_t *ptst = ptst_critical_enter();
+      sl_delete_node(node_todel, ptst);
+      ptst_critical_exit(ptst);
       return 1;
     } else {
       return 0;

--- a/c-cpp/src/skiplists/skiplist-lock/ptst.c
+++ b/c-cpp/src/skiplists/skiplist-lock/ptst.c
@@ -1,0 +1,97 @@
+/*
+ * ptst.c: per-thread state for threads operating on the skip list
+ *
+ * Author: Ian Dick, 2013.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "skiplist-lock.h"
+#include "ptst.h"
+#include "garbagecoll.h"
+
+/* - Globals - */
+pthread_key_t   ptst_key;
+ptst_t  *ptst_list;
+static unsigned int next_id;
+
+/* - Private function declarations - */
+static void ptst_destructor(ptst_t *ptst);
+
+/* - Private function definitions - */
+
+/**
+ * ptst_destructor - reclaim a recently released per-thread state
+ * @ptst: the per-thread state to reclaim
+ */
+static void ptst_destructor(ptst_t *ptst)
+{
+        ptst->count = 0;
+}
+
+/* - Public ptst functions - */
+
+/**
+ * ptst_critical_enter - enter/leave a critical section
+ *
+ * Returns a ptst handle for use by the calling thread during the 
+ * critical section.
+ */
+ptst_t* ptst_critical_enter(void)
+{
+        ptst_t *ptst, *next;
+        unsigned int id;
+
+        ptst = (ptst_t*) pthread_getspecific(ptst_key);
+        if (NULL == ptst) {
+                ptst = ptst_first();
+                for ( ; NULL != ptst; ptst = ptst_next(ptst)) {
+                        if ((0 == ptst->count) && CAS(&ptst->count, 0, 1))
+                                break;
+                }
+
+                if (NULL == ptst) {
+                        ptst = ALIGNED_ALLOC(sizeof(ptst_t));
+                        if (!ptst) {
+                                perror("malloc: sl_ptst_critial_enter\n");
+                                exit(1);
+                        }
+                        memset(ptst, 0, sizeof(*ptst));
+                        ptst->gc = gc_init();
+                        ptst->count = 1;
+                        id = next_id;
+                        while ((!CAS(&next_id, id, id+1)))
+                                id = next_id;
+                        ptst->id = id;
+                        do {
+                                next = ptst_list;
+                                ptst->next = next;
+                        } while (!CAS(&ptst_list, next, ptst));
+                }
+
+                pthread_setspecific(ptst_key, ptst);
+        }
+
+        gc_enter(ptst);
+
+        return ptst;
+}
+
+/**
+ * ptst_subsystem_init - initialise the ptst subsystem
+ *
+ * Note: This should only happen once at the start of the application.
+ */
+void ptst_subsystem_init(void)
+{
+        ptst_list = NULL;
+        next_id      = 0;
+        BARRIER();
+        if (pthread_key_create(&ptst_key, (void (*)(void *))ptst_destructor)) {
+                perror("pthread_key_create: ptst_subsystem_init\n");
+                exit(1);
+        }
+}

--- a/c-cpp/src/skiplists/skiplist-lock/ptst.h
+++ b/c-cpp/src/skiplists/skiplist-lock/ptst.h
@@ -1,0 +1,43 @@
+/*
+ * the per-thread state interface
+ */
+#ifndef PTST_H_
+#define PTST_H_
+
+#include <pthread.h>
+
+typedef struct sl_ptst ptst_t;
+
+#include "garbagecoll.h"
+
+struct sl_ptst {
+        /* thread id */
+        unsigned int id;
+
+        /* state management */
+        struct sl_ptst *next;
+        unsigned int   count;
+
+        /* utility structures */
+        gc_st *gc;
+        unsigned long rand;
+};
+
+extern pthread_key_t ptst_key;
+
+/*
+ * enter/leave a critical section - a thread gets a state handle for
+ * use during critical regions
+ */
+ptst_t* ptst_critical_enter(void);
+#define ptst_critical_exit(_p) gc_exit(_p);
+
+/* Iterators */
+extern ptst_t *ptst_list;
+#define ptst_first() (ptst_list)
+#define ptst_next(_p) ((_p)->next)
+
+/* Called once at the beginning of the application */
+void ptst_subsystem_init(void);
+
+#endif /* PTST_H_ */

--- a/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.c
+++ b/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.c
@@ -25,6 +25,8 @@
 
 unsigned int levelmax;
 
+static int gc_id[MAX_SIZES];
+
 inline void *xmalloc(size_t size)
 {
 	void *p = malloc(size);
@@ -74,12 +76,12 @@ int floor_log_2(unsigned int n) {
 /* 
  * Create a new node without setting its next fields. 
  */
-sl_node_t *sl_new_simple_node(val_t val, int toplevel, int transactional)
+sl_node_t *sl_new_simple_node(val_t val, int toplevel, int transactional, ptst_t *ptst)
 {
 	sl_node_t *node;
 	
-	node = (sl_node_t *)xmalloc(sizeof(sl_node_t));
-	node->next = (sl_node_t **)xmalloc(toplevel * sizeof(sl_node_t *));
+    node = gc_alloc(ptst, gc_id[0]);
+    node->next = gc_alloc(ptst, gc_id[1]);
 	node->val = val;
 	node->toplevel = toplevel;
 	node->marked = 0;
@@ -92,12 +94,12 @@ sl_node_t *sl_new_simple_node(val_t val, int toplevel, int transactional)
  * Create a new node with its next field. 
  * If next=NULL, then this create a tail node. 
  */
-sl_node_t *sl_new_node(val_t val, sl_node_t *next, int toplevel, int transactional)
+sl_node_t *sl_new_node(val_t val, sl_node_t *next, int toplevel, int transactional, ptst_t *ptst)
 {
 	sl_node_t *node;
 	int i;
 	
-	node = sl_new_simple_node(val, toplevel, transactional);
+	node = sl_new_simple_node(val, toplevel, transactional, ptst);
 	
 	for (i = 0; i < toplevel; i++)
 		node->next[i] = next;
@@ -105,35 +107,35 @@ sl_node_t *sl_new_node(val_t val, sl_node_t *next, int toplevel, int transaction
 	return node;
 }
 
-void sl_delete_node(sl_node_t *n)
+void sl_delete_node(sl_node_t *n, ptst_t *ptst)
 {
 	DESTROY_LOCK(&n->lock);
-	free(n->next);
-	free(n);
+    gc_free(ptst, (void*)n->next, gc_id[1]);
+    gc_free(ptst, (void*)n, gc_id[0]);
 }
 
-sl_intset_t *sl_set_new()
+sl_intset_t *sl_set_new(ptst_t *ptst)
 {
 	sl_intset_t *set;
 	sl_node_t *min, *max;
 	
 	set = (sl_intset_t *)xmalloc(sizeof(sl_intset_t));
-	max = sl_new_node(VAL_MAX, NULL, levelmax, 0);
-	min = sl_new_node(VAL_MIN, max, levelmax, 0);
+	max = sl_new_node(VAL_MAX, NULL, levelmax, 0, ptst);
+	min = sl_new_node(VAL_MIN, max, levelmax, 0, ptst);
 	max->fullylinked = 1;
 	min->fullylinked = 1;
 	set->head = min;
 	return set;
 }
 
-void sl_set_delete(sl_intset_t *set)
+void sl_set_delete(sl_intset_t *set, ptst_t *ptst)
 {
 	sl_node_t *node, *next;
 	
 	node = set->head;
 	while (node != NULL) {
 		next = node->next[0];
-		sl_delete_node(node);
+		sl_delete_node(node, ptst);
 		node = next;
 	}
 	free(set);
@@ -153,4 +155,13 @@ int sl_set_size(sl_intset_t *set)
 	}
 	
 	return size;
+}
+
+/**
+ * set_subsystem_init - initialise the set subsystem
+ */
+void set_subsystem_init(void)
+{
+        gc_id[0]  = gc_add_allocator(sizeof(sl_node_t));
+        gc_id[1]  = gc_add_allocator(levelmax * sizeof(sl_node_t *));
 }

--- a/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
+++ b/c-cpp/src/skiplists/skiplist-lock/skiplist-lock.h
@@ -33,6 +33,15 @@
 #include <stdint.h>
 
 #include <atomic_ops.h>
+#include "common.h"
+#include "ptst.h"
+#include "garbagecoll.h"
+
+/*
+ * number of unique blk sizes we want to deal with
+ * (1 for node and 1 for next pointer array)
+ */
+#define MAX_SIZES 2
 
 #define DEFAULT_DURATION                10000
 #define DEFAULT_INITIAL                 256
@@ -101,14 +110,16 @@ int floor_log_2(unsigned int n);
 /* 
  * Create a new node without setting its next fields. 
  */
-sl_node_t *sl_new_simple_node(val_t val, int toplevel, int transactional);
+sl_node_t *sl_new_simple_node(val_t val, int toplevel, int transactional, ptst_t *ptst);
 /* 
  * Create a new node with its next field. 
  * If next=NULL, then this create a tail node. 
  */
 sl_node_t *sl_new_node(val_t val, sl_node_t *next, int toplevel, int 
-transactional);
-void sl_delete_node(sl_node_t *n);
-sl_intset_t *sl_set_new();
-void sl_set_delete(sl_intset_t *set);
+transactional, ptst_t *ptst);
+void sl_delete_node(sl_node_t *n, ptst_t *ptst);
+sl_intset_t *sl_set_new(ptst_t *ptst);
+void sl_set_delete(sl_intset_t *set, ptst_t *ptst);
 int sl_set_size(sl_intset_t *set);
+
+void set_subsystem_init(void);


### PR DESCRIPTION
**Issue:**
The use of `malloc` to allocate memory results in excessive `mprotect` system calls which prevents the algorithm to present linear scale-ability under contention. Additionally the `wait-free` membership operations require some form of intelligent garbage collection to `free` such as epoch-based.

**Solution:**
Employ an alternate memory allocation mechanism. Note: the epoch-based garbage collector was observed to perform equally with `tcmalloc`. 

**Benchmarks:**
These [graphs](http://i.imgur.com/pDsIysD.png) compare `malloc` with `garbagecoll`.

Small Skiplists
- contented workloads: significantly improved performance and linear scale-ability is now presented!
- non-contended workloads: significantly improved performance and linear scale-ability is now presented!

Larger Skiplists
- contented workloads: significantly improved performance and linear scale-ability is now presented!
- non-contended workloads: reduced performance compared to `malloc` (but no reclamation possible)

Skiplists need to be able to perform under contention, additionally they should provide the ability to reclaim memory, therefore even though a reduction in performance is presented in large non-contended workloads this change seems to be required.

**Test System:**

- 2x Intel(R) Xeon(R) CPU E5-2450 @ 2.10GHz with 128GB RAM gcc 6.2.1 x86_64-pc-linux-gnu

**Epoch-Based Garbage Collector:**

- Uses Ian Dick's implementation of the epoch-based garbage collector presented by Keir Fraser.