### PR TITLE
Fix inline semantics for GNU11 standard.

### DIFF
--- a/c-cpp/src/hashtables/lockbased-ht/test.c
+++ b/c-cpp/src/hashtables/lockbased-ht/test.c
@@ -76,6 +76,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -89,6 +90,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/hashtables/lockfree-ht/test.c
+++ b/c-cpp/src/hashtables/lockfree-ht/test.c
@@ -84,6 +84,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -97,6 +98,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;

--- a/c-cpp/src/linkedlists/lazy-list/test.c
+++ b/c-cpp/src/linkedlists/lazy-list/test.c
@@ -73,6 +73,7 @@ inline long rand_range(long r) {
   } while (r > 0);
   return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -86,6 +87,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
   } while (r > 0);
   return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;

--- a/c-cpp/src/linkedlists/lock-coupling-list/test.c
+++ b/c-cpp/src/linkedlists/lock-coupling-list/test.c
@@ -73,6 +73,7 @@ inline long rand_range(long r) {
   } while (r > 0);
   return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -86,6 +87,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
   } while (r > 0);
   return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;

--- a/c-cpp/src/linkedlists/lockfree-list/test.c
+++ b/c-cpp/src/linkedlists/lockfree-list/test.c
@@ -76,6 +76,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -89,6 +90,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/linkedlists/selfish/test.c
+++ b/c-cpp/src/linkedlists/selfish/test.c
@@ -123,6 +123,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -136,6 +137,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/linkedlists/versioned/test.c
+++ b/c-cpp/src/linkedlists/versioned/test.c
@@ -107,6 +107,7 @@ inline long rand_range(long r) {
     } while (r > 0);
     return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -120,6 +121,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
     } while (r > 0);
     return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/skiplists/fraser/test.c
+++ b/c-cpp/src/skiplists/fraser/test.c
@@ -135,6 +135,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -148,6 +149,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
 	unsigned int first;

--- a/c-cpp/src/skiplists/nohotspot/test.c
+++ b/c-cpp/src/skiplists/nohotspot/test.c
@@ -140,6 +140,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -153,6 +154,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
 	unsigned int first;

--- a/c-cpp/src/skiplists/rotating/test.c
+++ b/c-cpp/src/skiplists/rotating/test.c
@@ -136,6 +136,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -149,6 +150,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
 	unsigned int first;

--- a/c-cpp/src/skiplists/sequential/test.c
+++ b/c-cpp/src/skiplists/sequential/test.c
@@ -82,6 +82,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -95,6 +96,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
 	val_t first;

--- a/c-cpp/src/skiplists/skiplist-lock/test.c
+++ b/c-cpp/src/skiplists/skiplist-lock/test.c
@@ -84,6 +84,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -97,6 +98,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
   } while (r > 0);
   return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;

--- a/c-cpp/src/trees/avl/test.c
+++ b/c-cpp/src/trees/avl/test.c
@@ -97,6 +97,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -118,6 +119,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/trees/lfbstree/test.c
+++ b/c-cpp/src/trees/lfbstree/test.c
@@ -111,6 +111,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -132,6 +133,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 void *test3(void *data) {

--- a/c-cpp/src/trees/newavltree/test.c
+++ b/c-cpp/src/trees/newavltree/test.c
@@ -84,6 +84,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -97,6 +98,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/trees/rbtree/test.c
+++ b/c-cpp/src/trees/rbtree/test.c
@@ -82,6 +82,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -95,6 +96,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;

--- a/c-cpp/src/trees/sftree/test.c
+++ b/c-cpp/src/trees/sftree/test.c
@@ -98,6 +98,7 @@ inline long rand_range(long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range(long r);
 
 /* Thread-safe, re-entrant version of rand_range(r) */
 inline long rand_range_re(unsigned int *seed, long r) {
@@ -119,6 +120,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
 	} while (r > 0);
 	return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 
 typedef struct thread_data {

--- a/c-cpp/src/trees/tree-lock/test.c
+++ b/c-cpp/src/trees/tree-lock/test.c
@@ -156,6 +156,7 @@ inline long rand_range_re(unsigned int *seed, long r) {
   } while (r > 0);
   return v;
 }
+long rand_range_re(unsigned int *seed, long r);
 
 typedef struct thread_data {
   val_t first;


### PR DESCRIPTION
**Overview:**
According to the [GCC manual](https://gcc.gnu.org/onlinedocs/gcc/Inline.html#Inline) GNU11 now enables C99 inline semantics instead of older GNU inline semantics: the use of inline does not guarantee a function is inlined or even that a symbol is generated.

**Problem:**
When compiling Synchrobench in debug mode `VERSION=DEBUG make` no optimizations are used therefore GCC does not inline functions thus **compilation fails** due to being unable to find the symbols for the inline declared/defined functions:

- `... undefined reference to 'rand_range_re'`
- `... undefined reference to 'rand_range'`

**Solution:**
Force the generation of a symbol.