### PR TITLE
Improve compatibility with older compiler versions

### DIFF
--- a/c-cpp/INSTALL
+++ b/c-cpp/INSTALL
@@ -23,6 +23,11 @@ INSTALL
    * sequential-rbtree
    * sequential-skiplist
 
+LANGUAGE STANDARD REVISIONS
+------------------------
+   Most data structures compile with GNU89 however some require GNU11 features 
+   only supported with: GCC from version 4.9 and Clang from version 3.6.
+
 SYNCHRONIZATIONS
 ----------------
    

--- a/c-cpp/Makefile
+++ b/c-cpp/Makefile
@@ -1,8 +1,16 @@
 .PHONY:	all
 
 BENCHS = src/trees/sftree src/linkedlists/lockfree-list src/hashtables/lockfree-ht src/trees/rbtree src/skiplists/sequential
-LBENCHS = src/trees/tree-lock src/linkedlists/lock-coupling-list src/linkedlists/lazy-list src/linkedlists/versioned src/hashtables/lockbased-ht src/skiplists/skiplist-lock 
+LBENCHS = src/trees/tree-lock src/linkedlists/lock-coupling-list src/linkedlists/lazy-list src/hashtables/lockbased-ht src/skiplists/skiplist-lock
 LFBENCHS = src/trees/lfbstree src/linkedlists/lockfree-list src/hashtables/lockfree-ht src/skiplists/rotating src/skiplists/fraser src/skiplists/nohotspot
+
+# Only compile C11/GNU11 algorithms with compatible compiler
+GCC_GTEQ_490 := $(shell expr `gcc -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
+ifeq "$(GCC_GTEQ_490)" "1"
+	BENCHS +=
+	LBENCHS += src/linkedlists/versioned
+	LFBENCHS += src/linkedlists/selfish
+endif
 
 #MAKEFLAGS+=-j4
 

--- a/c-cpp/src/skiplists/nohotspot/intset.c
+++ b/c-cpp/src/skiplists/nohotspot/intset.c
@@ -29,15 +29,15 @@
 
 int sl_contains_old(set_t *set, unsigned int key, int transactional)
 {
-        return sl_contains(set, (key_t) key);
+        return sl_contains(set, (sl_key_t) key);
 }
 
 int sl_add_old(set_t *set, unsigned int key, int transactional)
 {
-        return sl_insert(set, (key_t) key, (val_t) ((long)key));
+        return sl_insert(set, (sl_key_t) key, (val_t) ((long)key));
 }
 
 int sl_remove_old(set_t *set, unsigned int key, int transactional)
 {
-	return sl_delete(set, (key_t) key);
+	return sl_delete(set, (sl_key_t) key);
 }


### PR DESCRIPTION
**Problem:**

Compiling Synchrobench with older compilers fails due to: a bug in nohotspot; the introduction of new algorithms that require C11/GNU11.

**Solution:**

1. Restrict compilation of C11/GNU11 algorithms to GCC >= 4.9.0.
2. Resolve bug in nohotspot where the use of an undeclared identifier sometimes causes compilation to fail.

**Future:**

A more robust make system.