### PR TITLE
Java skiplists normalize level/height RNG and maxLevel/maxHeight.

### DIFF
--- a/java/src/skiplists/RandomLevelGenerator.java
+++ b/java/src/skiplists/RandomLevelGenerator.java
@@ -1,0 +1,36 @@
+package skiplists;
+
+import java.util.Random;
+
+public class RandomLevelGenerator {
+    /**
+     * Generates the initial random seed for the cheaper per-instance random number generators used in randomLevel.
+     */
+    private static final Random seedGenerator = new Random();
+
+    /**
+     * Seed for simple random number generator. Not volatile since it doesn't matter too much if different threads don't
+     * see updates.
+     */
+    private static transient int randomSeed = seedGenerator.nextInt() | 0x0100;
+
+    /**
+     * Returns a random level for inserting a new node. Hardwired to k=1, p=0.5, max 31 (see above and Pugh's
+     * "Skip List Cookbook", sec 3.4).
+     *
+     * This uses the simplest of the generators described in George Marsaglia's "Xorshift RNGs" paper. This is not a
+     * high-quality generator but is acceptable here.
+     */
+    public static int randomLevel() {
+        int x = randomSeed;
+        x ^= x << 13;
+        x ^= x >>> 17;
+        randomSeed = x ^= x << 5;
+        if ((x & 0x80000001) != 0) // test highest and lowest bits
+            return 0; /* WARN: MIN IS 0 */
+        int level = 1;
+        while (((x >>>= 1) & 1) != 0)
+            ++level;
+        return level;
+    }
+}

--- a/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
+++ b/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
@@ -90,7 +90,7 @@ public class NonBlockingFriendlySkipListMap<K, V> extends AbstractMap<K, V>
 	/**
 	 * The maximum height the skip list can reach
 	 */
-	private static final int totalHeight = 40;
+	private static final int totalHeight = 31;
 
 	/**
 	 * The height of the skip list to start

--- a/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
+++ b/java/src/skiplists/lockfree/NonBlockingFriendlySkipListMap.java
@@ -67,18 +67,6 @@ public class NonBlockingFriendlySkipListMap<K, V> extends AbstractMap<K, V>
 	private static final ConcurrentLinkedQueue<NonBlockingFriendlySkipListMap> skipLists = new ConcurrentLinkedQueue<NonBlockingFriendlySkipListMap>();
 
 	/**
-	 * Seed for simple random number generator. Not volatile since it doesn't
-	 * matter too much if different threads don't see updates.
-	 */
-	private transient int randomSeed;
-
-	/**
-	 * Generates the initial random seed for the cheaper per-instance random
-	 * number generators used in randomLevel.
-	 */
-	private static final Random seedGenerator = new Random();
-
-	/**
 	 * Number of times the bottom indexItem level has been removed
 	 */
 	private final AtomicInteger bottomLevelRaiseCount = new AtomicInteger();
@@ -432,7 +420,6 @@ public class NonBlockingFriendlySkipListMap<K, V> extends AbstractMap<K, V>
 		begin.next = null;
 		begin.vars.topLevel = totalHeight;
 		// begin.vars.bottomLevel = 0;
-		randomSeed = seedGenerator.nextInt() | 0x0100;
 
 		// The following lines create a new node of maximum initial height
 		// used as the "root" node in the list, and points the beginning
@@ -1628,16 +1615,7 @@ public class NonBlockingFriendlySkipListMap<K, V> extends AbstractMap<K, V>
 	 * acceptable here.
 	 */
 	private int randomLevel() {
-		int x = randomSeed;
-		x ^= x << 13;
-		x ^= x >>> 17;
-		randomSeed = x ^= x << 5;
-		if ((x & 0x80000001) != 0) // test highest and lowest bits
-			return 0;
-		int level = 1;
-		while (((x >>>= 1) & 1) != 0)
-			++level;
-		return level;
+		return Math.min((totalHeight - 1), (skiplists.RandomLevelGenerator.randomLevel()));
 	}
 
 	/**

--- a/java/src/skiplists/lockfree/NonBlockingJavaSkipListMap.java
+++ b/java/src/skiplists/lockfree/NonBlockingJavaSkipListMap.java
@@ -303,12 +303,6 @@ public class NonBlockingJavaSkipListMap<K, V> extends AbstractMap<K, V>
 	private static final long serialVersionUID = -8627078645895051609L;
 
 	/**
-	 * Generates the initial random seed for the cheaper per-instance random
-	 * number generators used in randomLevel.
-	 */
-	private static final Random seedGenerator = new Random();
-
-	/**
 	 * Special value used to identify base-level header
 	 */
 	private static final Object BASE_HEADER = new Object();
@@ -325,12 +319,6 @@ public class NonBlockingJavaSkipListMap<K, V> extends AbstractMap<K, V>
 	 * @serial
 	 */
 	private final Comparator<? super K> comparator;
-
-	/**
-	 * Seed for simple random number generator. Not volatile since it doesn't
-	 * matter too much if different threads don't see updates.
-	 */
-	private transient int randomSeed;
 
 	/** Lazily initialized key set */
 	private transient KeySet keySet;
@@ -351,7 +339,6 @@ public class NonBlockingJavaSkipListMap<K, V> extends AbstractMap<K, V>
 		entrySet = null;
 		values = null;
 		descendingMap = null;
-		randomSeed = seedGenerator.nextInt() | 0x0100; // ensure nonzero
 		head = new HeadIndex<K, V>(new Node<K, V>(null, BASE_HEADER, null),
 				null, null, 1);
 	}
@@ -1025,16 +1012,7 @@ public class NonBlockingJavaSkipListMap<K, V> extends AbstractMap<K, V>
 	 * acceptable here.
 	 */
 	private int randomLevel() {
-		int x = randomSeed;
-		x ^= x << 13;
-		x ^= x >>> 17;
-		randomSeed = x ^= x << 5;
-		if ((x & 0x80000001) != 0) // test highest and lowest bits
-			return 0;
-		int level = 1;
-		while (((x >>>= 1) & 1) != 0)
-			++level;
-		return level;
+		return skiplists.RandomLevelGenerator.randomLevel();
 	}
 
 	/**

--- a/java/src/skiplists/sequential/SequentialSkipListIntSet.java
+++ b/java/src/skiplists/sequential/SequentialSkipListIntSet.java
@@ -28,7 +28,7 @@ public class SequentialSkipListIntSet implements CompositionalIntSet {
     };
 	
     public SequentialSkipListIntSet() {
-        this(6);
+        this(31);
     }
     
     public SequentialSkipListIntSet(final int maxLevel) {

--- a/java/src/skiplists/sequential/SequentialSkipListIntSet.java
+++ b/java/src/skiplists/sequential/SequentialSkipListIntSet.java
@@ -13,15 +13,13 @@ import contention.abstractions.CompositionalIterator;
  */
 public class SequentialSkipListIntSet implements CompositionalIntSet {
 
-    /** The probability to increase level */
-    final private double probability;
     /** The maximum number of levels */
     final private int maxLevel;
     /** The first element of the list */
     final public Node head;
     /** The last element of the list */
     final public Node tail;
-    /** The thread-private PRNG */
+    /** The thread-private PRNG, used for fil(), not for height/level determination. */
     final private static ThreadLocal<Random> s_random = new ThreadLocal<Random>() {
         @Override
         protected synchronized Random initialValue() {
@@ -30,12 +28,11 @@ public class SequentialSkipListIntSet implements CompositionalIntSet {
     };
 	
     public SequentialSkipListIntSet() {
-        this(6, 0.25);
+        this(6);
     }
     
-    public SequentialSkipListIntSet(final int maxLevel, final double probability) {
+    public SequentialSkipListIntSet(final int maxLevel) {
 	this.maxLevel = maxLevel;
-	this.probability = probability;
 	this.head = new Node(maxLevel, Integer.MIN_VALUE);
 	this.tail = new Node(maxLevel, Integer.MAX_VALUE);
 	for (int i = 0; i <= maxLevel; i++) {
@@ -48,15 +45,11 @@ public class SequentialSkipListIntSet implements CompositionalIntSet {
 	    this.addInt(s_random.get().nextInt(range));
 	}
     }
-    
-    protected int randomLevel() {
-	int l = 0;
-	while (l < maxLevel && s_random.get().nextDouble() < probability) {
-	    l++;
+
+	private int randomLevel() {
+	    return Math.min((maxLevel - 1), (skiplists.RandomLevelGenerator.randomLevel()));
 	}
-	return l;
-    }
-    
+
     @Override
     public boolean containsInt(final int value) { 
 	boolean result;

--- a/java/src/skiplists/transactional/CompositionalSkipListIntSet.java
+++ b/java/src/skiplists/transactional/CompositionalSkipListIntSet.java
@@ -17,13 +17,11 @@ import contention.abstractions.CompositionalIterator;
  */
 public class CompositionalSkipListIntSet implements CompositionalIntSet {
 
-	/** The probability to increase level */
-    final private double probability;
     /** The maximum number of levels */
     final private int maxLevel;
     /** The first element of the list */
     final public Node head;
-    /** The thread-private PRNG */
+    /** The thread-private PRNG, used for fil(), not for height/level determination. */
     final private static ThreadLocal<Random> s_random = new ThreadLocal<Random>() {
         @Override
         protected synchronized Random initialValue() {
@@ -32,12 +30,11 @@ public class CompositionalSkipListIntSet implements CompositionalIntSet {
     };
 	
     public CompositionalSkipListIntSet() {
-        this(6, 0.25);
+        this(6);
     }
     
-	public CompositionalSkipListIntSet(final int maxLevel, final double probability) {
+	public CompositionalSkipListIntSet(final int maxLevel) {
 		this.maxLevel = maxLevel;
-		this.probability = probability;
 		this.head = new Node(maxLevel, Integer.MIN_VALUE);
 		final Node tail = new Node(maxLevel, Integer.MAX_VALUE);
 		for (int i = 0; i <= maxLevel; i++) {
@@ -52,11 +49,7 @@ public class CompositionalSkipListIntSet implements CompositionalIntSet {
 	}
 	
 	protected int randomLevel() {
-		int l = 0;
-		while (l < maxLevel && s_random.get().nextDouble() < probability) {
-			l++;
-		}
-		return l;
+	    return Math.min((maxLevel - 1), (skiplists.RandomLevelGenerator.randomLevel()));
 	}
 	
 	@Override

--- a/java/src/skiplists/transactional/CompositionalSkipListIntSet.java
+++ b/java/src/skiplists/transactional/CompositionalSkipListIntSet.java
@@ -30,7 +30,7 @@ public class CompositionalSkipListIntSet implements CompositionalIntSet {
     };
 	
     public CompositionalSkipListIntSet() {
-        this(6);
+        this(31);
     }
     
 	public CompositionalSkipListIntSet(final int maxLevel) {

--- a/java/src/skiplists/transactional/TransactionalPughSkipListSet.java
+++ b/java/src/skiplists/transactional/TransactionalPughSkipListSet.java
@@ -19,13 +19,11 @@ import contention.abstractions.CompositionalMap;
 public class TransactionalPughSkipListSet<K, V> implements CompositionalIntSet,
 		CompositionalMap<K, V> {
 
-	/** The probability to increase level */
-	final private double probability;
 	/** The maximum number of levels */
 	final private int maxLevel;
 	/** The first element of the list */
 	final public Node head;
-	/** The thread-private PRNG */
+    /** The thread-private PRNG, used for fil(), not for height/level determination. */
 	final private static ThreadLocal<Random> s_random = new ThreadLocal<Random>() {
 		@Override
 		protected synchronized Random initialValue() {
@@ -34,13 +32,11 @@ public class TransactionalPughSkipListSet<K, V> implements CompositionalIntSet,
 	};
 
 	public TransactionalPughSkipListSet() {
-		this(6, 0.25);
+		this(6);
 	}
 
-	public TransactionalPughSkipListSet(final int maxLevel,
-			final double probability) {
+	public TransactionalPughSkipListSet(final int maxLevel) {
 		this.maxLevel = maxLevel;
-		this.probability = probability;
 		this.head = new Node(maxLevel, Integer.MIN_VALUE);
 		final Node tail = new Node(maxLevel, Integer.MAX_VALUE);
 		for (int i = 0; i <= maxLevel; i++) {
@@ -55,11 +51,7 @@ public class TransactionalPughSkipListSet<K, V> implements CompositionalIntSet,
 	}
 
 	protected int randomLevel() {
-		int l = 0;
-		while (l < maxLevel && s_random.get().nextDouble() < probability) {
-			l++;
-		}
-		return l;
+	    return Math.min((maxLevel - 1), (skiplists.RandomLevelGenerator.randomLevel()));
 	}
 
 	@Atomic(metainf = "NT")

--- a/java/src/skiplists/transactional/TransactionalPughSkipListSet.java
+++ b/java/src/skiplists/transactional/TransactionalPughSkipListSet.java
@@ -32,7 +32,7 @@ public class TransactionalPughSkipListSet<K, V> implements CompositionalIntSet,
 	};
 
 	public TransactionalPughSkipListSet() {
-		this(6);
+		this(31);
 	}
 
 	public TransactionalPughSkipListSet(final int maxLevel) {


### PR DESCRIPTION
**Overview:**

The skiplists were using various random number generators internally to decide on the level/height of a node/tower. Additionally the maxLevel/maxHeight considerably varied.

**Problem:**

These discrepancies significantly alter the performance of the algorithms thus reducing the validity of comparisons.

**Solution:**

Create a common `RandomLevelGenerator.java` for use by all the skiplists. Also temporarily manually set the maxLevel/maxHeight to 31 (the max output from the RNG).

**Testing:**

Algorithms were tested using `java-8-openjdk`, existing RNG were evaluated before modification to ensure the minimums and maximums were correctly maintained.