### PR TITLE
Add typedefs for uint and ulong types on MacOS

### DIFF
--- a/c-cpp/src/trees/sftree/sftree.h
+++ b/c-cpp/src/trees/sftree/sftree.h
@@ -232,6 +232,10 @@ extern unsigned int levelmax;
 #define TMRBTREE_CONTAINS(r, k)   TMrbtree_contains(TM_ARG  r, (void*)(k))
 #endif
 
+#ifdef __APPLE__ && __MACH__
+typedef unsigned int uint;
+typedef unsigned long ulong;
+#endif
 
 typedef intptr_t val_t;
 //#define val_t void*


### PR DESCRIPTION
MacOS doesn't have the types uint and ulong (unsigned int and unsigned long respectively) when using the default compilation environment. I added some conditional type definitions to allow compilation to succeed on MacOS.