### PR TITLE
Fix potential out-of-bounds error

### DIFF
--- a/c-cpp/src/skiplists/numask/test.cpp
+++ b/c-cpp/src/skiplists/numask/test.cpp
@@ -573,7 +573,7 @@ int main(int argc, char **argv)
 		if (sl_add_old(search_layers[cur_zone], val, 0)) {
 			last = val;
 			i++;
-			if(i %(initial / 4) == 0 && cur_zone != 3) {
+			if(i %(initial / num_numa_zones) == 0 && cur_zone != num_numa_zones - 1) {
 				numa_run_on_node(++cur_zone);
 			}
 		}


### PR DESCRIPTION
If the environment has less than or equal to 4 numa zones, this section of code will access memory outside the bounds of the search_layer array... it assumes there's exactly 4 numa zones no matter the specification