### PR TITLE
Fix for lazy linked list

### DIFF
--- a/c-cpp/src/linkedlists/lazy-list/lazy.c
+++ b/c-cpp/src/linkedlists/lazy-list/lazy.c
@@ -54,7 +54,7 @@ inline node_l_t *get_marked_ref(node_l_t *n) {
  * points to curr to verify that the entries are adjacent and present in the list.
  */
 inline int parse_validate(node_l_t *pred, node_l_t *curr) {
-	return (!is_marked_ref((long) pred) && !is_marked_ref((long) curr) && (pred->next == curr));
+	return (!is_marked_ref((long) pred->next) && !is_marked_ref((long) curr->next) && (pred->next == curr));
 }
 
 int parse_find(intset_l_t *set, val_t val) {

--- a/c-cpp/src/linkedlists/lazy-list/lazy.c
+++ b/c-cpp/src/linkedlists/lazy-list/lazy.c
@@ -62,7 +62,7 @@ int parse_find(intset_l_t *set, val_t val) {
 	curr = set->head;
 	while (curr->val < val)
 		curr = get_unmarked_ref(curr->next);
-	return ((curr->val == val) && !is_marked_ref((long) curr));
+	return ((curr->val == val) && !is_marked_ref((long) curr->next));
 }
 
 int parse_insert(intset_l_t *set, val_t val) {


### PR DESCRIPTION
The lazy linked list implementation has two issues currently:

1. When doing checks for the marked bit, the checks are not occurring on the next field in the current and previous nodes. The checks are instead occurring on the pointers to the current and previous nodes, which breaks correctness.

2. The lazy linked list may return that it was unsuccessful if the validation is unsuccessful, which is semantically incorrect.

These updates fix these issues.

